### PR TITLE
Fix save query

### DIFF
--- a/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.ts
+++ b/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.ts
@@ -40,7 +40,7 @@ export class QueryEditV3Component implements OnInit, OnDestroy {
                 .pipe(take(1))
                 .subscribe(
                     val => {
-                        if(val.created === true || val.result === 'updated') {
+                        if(val.result === 'created' || val.result === 'updated') {
                             this.snackBar.open('query saved.', '', { duration: 2000 })
                         }else{
                             this.snackBar.open('error: query not saved.', '', { duration: 2000 })

--- a/frontend/src/app/admin/programs/services/query.service.ts
+++ b/frontend/src/app/admin/programs/services/query.service.ts
@@ -37,7 +37,7 @@ export class QueryService {
             .pipe(
                 map(res => res.json()),
                 tap( res => {
-                    if (res.created === true || res.result === 'updated') {
+                    if (res.result === 'created' || res.result === 'updated') {
                         query.conditions = query.conditions.sort( (a, b) => a.data.key.name.localeCompare(b.data.key.name));
                         this.broadcast.next({
                             id: query.data.id,


### PR DESCRIPTION
When a new query is created, created = null and result = 'created'. When a query is updated, created = null and result = 'updated'. Another way to fix this would be to have created be true when a query is made and false otherwise.