### PR TITLE
Fix program caching

### DIFF
--- a/frontend/src/app/admin/programs/application-edit/application-edit.component.html
+++ b/frontend/src/app/admin/programs/application-edit/application-edit.component.html
@@ -11,7 +11,7 @@
   </section>
 
   <main>
-    <mat-icon routerLink="../../edit/{{data.guid}}" [replaceUrl]="true" matTooltip="Edit description">create</mat-icon>
+    <mat-icon routerLink="../../edit/{{data.guid}}" [replaceUrl]="true" matTooltip="edit program details">create</mat-icon>
     <header id="program-details">
       <h3>{{ (program | async)?.user.data?.title }} query details </h3>
       <div>{{ (program | async)?.application.length }} queries local.</div>

--- a/frontend/src/app/admin/programs/application-edit/application-edit.component.ts
+++ b/frontend/src/app/admin/programs/application-edit/application-edit.component.ts
@@ -62,6 +62,7 @@ export class ApplicationEditComponent implements OnInit {
         const index = program.application.findIndex(q => q.data.id === query_id);
         if (wasDeleted && index >= 0) {
           program.application.splice(index, 1);
+          this.modelService.removeCachedQuery(program.guid, query_id);
           
           this.snackBar.open('query deleted','', {
             duration: 2000

--- a/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.ts
+++ b/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.ts
@@ -4,6 +4,7 @@ import { QueryService } from '../../services/query.service';
 import { Subscription } from 'rxjs';
 import { MatSnackBar } from '@angular/material';
 import { filter, take } from 'rxjs/operators'
+import { ProgramModelService } from '../../services/program-model.service';
 
 @Component({
     selector: 'app-query-edit-v3',
@@ -13,7 +14,7 @@ import { filter, take } from 'rxjs/operators'
 export class QueryEditV3Component implements OnInit, OnDestroy {
     @Input() programQuery: ProgramQueryClass;
     private _subscription: Subscription;
-    constructor(private service: QueryService, public snackBar: MatSnackBar) { }
+    constructor(private service: QueryService, private programModelService: ProgramModelService, public snackBar: MatSnackBar) { }
 
     ngOnInit() {
         this.programQuery.conditions.sort( (a, b) => a.data.question.text.localeCompare(b.data.question.text));
@@ -41,6 +42,7 @@ export class QueryEditV3Component implements OnInit, OnDestroy {
                 .subscribe(
                     val => {
                         if(val.result === 'created' || val.result === 'updated') {
+                            this.programModelService.updateCachedQuery(this.programQuery);
                             this.snackBar.open('query saved.', '', { duration: 2000 })
                         }else{
                             this.snackBar.open('error: query not saved.', '', { duration: 2000 })

--- a/frontend/src/app/admin/programs/program-edit/program-edit.component.html
+++ b/frontend/src/app/admin/programs/program-edit/program-edit.component.html
@@ -9,7 +9,7 @@
                     (click)="handleDeleteClick()"> clear </mat-icon>
             <mat-icon
                     id="save-program"
-                    matTooltip="save program queries"
+                    matTooltip="save program details"
                     (click)="handlSaveClick()">save</mat-icon>
             <mat-icon
                     id="edit-queries"

--- a/frontend/src/app/admin/programs/program-edit/program-edit.component.ts
+++ b/frontend/src/app/admin/programs/program-edit/program-edit.component.ts
@@ -65,7 +65,7 @@ export class ProgramEditComponent implements OnInit {
       this.program.pipe(
         take(1),
         map(p => p.data.guid),
-        flatMap(this.model.deleteProgram),
+        flatMap(guid => this.model.deleteProgram(guid)),
         tap(() => {
           this.display('delete success.')
           this.router.navigateByUrl('admin/programs/overview');

--- a/frontend/src/app/admin/programs/program-overview/program-overview.component.ts
+++ b/frontend/src/app/admin/programs/program-overview/program-overview.component.ts
@@ -75,6 +75,7 @@ export class ProgramOverviewComponent implements OnInit {
             this.model.deleteProgram(guid).pipe(take(1))
             .subscribe(success => {
                 if (success) {
+                    this.programs = this.model.getPrograms();
                     this.snackBar.open('program deleted successfully', '', { duration: 2000 })
                 } else {
                     this.snackBar.open('error deleting program', '', { duration: 2000 })

--- a/frontend/src/app/admin/programs/program-overview/program-overview.component.ts
+++ b/frontend/src/app/admin/programs/program-overview/program-overview.component.ts
@@ -32,20 +32,17 @@ export class ProgramOverviewComponent implements OnInit {
         private model: ProgramModelService) { }
 
     ngOnInit() {
-        console.log("HERE1")
         this.programs = merge(
             this.model.getPrograms(),
             this.filterService.form.valueChanges.pipe(distinctUntilChanged(), map(update => new helpers.FilterMessage(update))),
             this.programUpdate$
         )
         .pipe(
-            tap(console.log),
             helpers.updateState,
             helpers.applyFilter,
             pluck('programs'),
             shareReplay()
         )
-        console.log("HERE2")
     }
 
     handleDetailInspection(guid: string) {

--- a/frontend/src/app/admin/programs/services/program-model.service.ts
+++ b/frontend/src/app/admin/programs/services/program-model.service.ts
@@ -88,6 +88,20 @@ export class ProgramModelService {
             }))
     }
 
+    updateCachedQuery(updatedQuery: ProgramQueryClass) {
+        updatedQuery.form.value.conditions.forEach(condition => delete condition['type']);
+        this._cache.pipe(take(1))
+            .subscribe(cache => {
+                let program = cache.find(p => p.guid === updatedQuery.data.guid);
+                const index = program.application.findIndex(q => q.id === updatedQuery.data.id);
+                if (index >= 0) {
+                    program.application[index] = updatedQuery.form.value;
+                } else {
+                    program.application.push(updatedQuery.form.value);
+                }
+        })
+    }
+
     private getCredentials(): RequestOptions {
         try {
             return this.authService.getCredentials();

--- a/frontend/src/app/admin/programs/services/program-model.service.ts
+++ b/frontend/src/app/admin/programs/services/program-model.service.ts
@@ -102,6 +102,17 @@ export class ProgramModelService {
         })
     }
 
+    removeCachedQuery(program_guid: string, query_id: string) {
+        this._cache.pipe(take(1))
+            .subscribe(cache => {
+                let program = cache.find(p => p.guid === program_guid);
+                const index = program.application.findIndex(q => q.id === query_id);
+                if (index >= 0) {
+                    program.application.splice(index, 1);
+                }
+        })
+    }
+
     private getCredentials(): RequestOptions {
         try {
             return this.authService.getCredentials();

--- a/frontend/src/app/admin/programs/services/program-model.service.ts
+++ b/frontend/src/app/admin/programs/services/program-model.service.ts
@@ -9,6 +9,7 @@ import { AuthService } from '../../core/services/auth.service'
 import { Program } from './program.class';
 import { FormBuilder } from '@angular/forms';
 import { environment } from '../../../../environments/environment'
+import { ProgramQueryClass } from './program-query.class';
 
 @Injectable()
 export class ProgramModelService {
@@ -57,9 +58,8 @@ export class ProgramModelService {
                     const val = cache.find(p => p.guid === program.guid);
                     if (val) {
                         val.user = program;
-                        //this._cache.next(cache);
                     } else {
-                        //this._cache.next([{guid: program.guid, application: [], user: program},  ...cache]);
+                        cache.push({guid: program.guid, application: [], user: program})
                     }
             })
         }
@@ -80,7 +80,10 @@ export class ProgramModelService {
         return this._deleteProgram(guid)
             .pipe(tap(res => {
                 if (res) {
-                    //this._cache.asObservable().pipe(take(1)).subscribe(cache => this._cache.next(cache.filter(p => p.guid !== guid)))
+                    this._cache.subscribe(cache => {
+                        const index = cache.findIndex(p => p.user.guid === guid)
+                        cache.splice(index, 1);
+                    })
                 }
             }))
     }

--- a/frontend/src/app/admin/programs/services/program-model.service.ts
+++ b/frontend/src/app/admin/programs/services/program-model.service.ts
@@ -46,7 +46,7 @@ export class ProgramModelService {
 
     getPrograms(): Observable<ApplicationFacingProgram[]> {
         if (this._cache) {
-            this._cache.subscribe(console.dir)
+            this._cache.subscribe();
             return this._cache
         } 
     }


### PR DESCRIPTION
Fixes #81. Fixes #80. 

Programs are cached the first time ProgramModelService getPrograms() is called. Currently the cache is only updated when the details of a program are edited. If a program is deleted or queries are edited, the user must refresh the page to see that the changes have taken effect. I added code to update the program cache when
- a program is created
- a program is deleted
- a query is modified
- a query is created
- a query is deleted

This also fixes the problem of potentially creating a program where the program queries and program details have a different guid as discussed in #81.

Now when you delete a program from the program overview, the program list UI will be updated immediately.

I also have the fix for the program deletion while in program-edit here (#80).
