### PR TITLE
Fix delete query response and delete program response

### DIFF
--- a/backend/src/modules/Program/program.service.test.ts
+++ b/backend/src/modules/Program/program.service.test.ts
@@ -115,4 +115,25 @@ describe('ProgramService', () => {
             expect(await programService.mGetByGuid(guids)).toMatchObject(result);
         })
     })
+
+    describe('deleteByGuid', () => {
+
+        it('should return a delete response indicating true', async () => {
+            const guid = 'test guid7';
+            const result = {deleted: true};
+
+            jest.spyOn(programService, 'deleteByGuid').mockImplementation(() => result);
+
+            expect(await programService.deleteByGuid(guid)).toMatchObject(result);
+        })
+
+        it('should return a delete response indicating false', async () => {
+            const guid = 'test guid6';
+            const result = {deleted: false};
+
+            jest.spyOn(programService, 'deleteByGuid').mockImplementation(() => result);
+
+            expect(await programService.deleteByGuid(guid)).toMatchObject(result);
+        })
+    })
 });

--- a/backend/src/modules/db.elasticsearch/client.service.ts
+++ b/backend/src/modules/db.elasticsearch/client.service.ts
@@ -66,7 +66,7 @@ export class ClientService {
             console.log(err);
             return err
         })
-        .then(() => ({ deleted: true}) )
+        .then((res: any) => res.result === 'deleted' ? {deleted: true} : {deleted: false})
     }
 
     async findAll(baseParams): Promise<any[]> {

--- a/backend/src/modules/protected/protected.controller.ts
+++ b/backend/src/modules/protected/protected.controller.ts
@@ -132,6 +132,7 @@ export class ProtectedController {
             this.programService.deleteByGuid(guid),
             this.queryService.deleteByGuid(guid)
         )
+        .map(([programDeleted, queriesDeleted]) => ({...programDeleted, ...queriesDeleted}))
     }
 
     @Delete('/query/:id')

--- a/backend/src/modules/query/EsQuery.service.ts
+++ b/backend/src/modules/query/EsQuery.service.ts
@@ -57,12 +57,17 @@ export class EsQueryService {
         return Promise.all(guids.map(guid => this.getByGuid(guid)))
     }
 
-    deleteByGuid(guid: string): any {
+    deleteByGuid(guid: string): Promise<any> {
         return this.clientService.client.deleteByQuery({
             index: this.INDEX,
             type: this.TYPE,
             body: { query: { match: { "meta.program_guid": guid } } }
         })
+        .catch(err => {
+            console.log(err)
+            return err
+        })
+        .then((res: any) => ({queries_deleted: res.deleted }))
     }
 
     deleteById(id: string): any {

--- a/backend/src/modules/query/EsQuery.service.ts
+++ b/backend/src/modules/query/EsQuery.service.ts
@@ -70,7 +70,7 @@ export class EsQueryService {
         .then((res: any) => ({queries_deleted: res.deleted }))
     }
 
-    deleteById(id: string): any {
+    deleteById(id: string): Promise<any> {
         return this.clientService.delete(this.INDEX, this.TYPE, id)
     }
 

--- a/backend/src/modules/query/EsQueryService.test.ts
+++ b/backend/src/modules/query/EsQueryService.test.ts
@@ -89,4 +89,35 @@ describe('EsQueryService', () => {
             expect(await queryService.create(mockDTO)).toMatchObject(result);
         });
     });
+
+    describe('deleteById', () => {
+        it('should return an elasticsearch delete response', async () => {
+            const query_id = "74ofh3kZhnIglDGC7sKqYeDJJT";
+            const result = {
+                "_index": "master_screener",
+                "_type": "queries",
+                "_id": "74ofh3kZhnIglDGC7sKqYeDJJT",
+                "_version": 2,
+                "result": "deleted",
+                "_shards": {
+                    "total": 2,
+                    "successful": 1,
+                    "failed": 0
+                },
+                "_seq_no": 61,
+                "_primary_term": 1
+            };
+            jest.spyOn(queryService, 'deleteById').mockImplementation(() => result);
+            expect(await queryService.deleteById(query_id)).toMatchObject(result);
+        });
+    });
+
+    describe('deleteByGuid', () => {
+        it('should return the number of queries deleted', async () => {
+            const program_guid = "tWucjcIELoF0O1Z0DksuXWDGY7";
+            const result = {queries_deleted: 5};
+            jest.spyOn(queryService, 'deleteByGuid').mockImplementation(() => result);
+            expect(await queryService.deleteByGuid(program_guid)).toMatchObject(result);
+        });
+    });
 });

--- a/frontend/src/app/admin/programs/program-edit/program-edit.component.ts
+++ b/frontend/src/app/admin/programs/program-edit/program-edit.component.ts
@@ -68,10 +68,11 @@ export class ProgramEditComponent implements OnInit {
         flatMap(guid => this.model.deleteProgram(guid))
       ).subscribe((deleteResponse) => {
         if (deleteResponse) {
-          this.display('delete success.')
+          this.display('delete success.');
           this.router.navigateByUrl('admin/programs/overview');
+        } else {
+          this.display('delete failure.');
         }
-        this.display('delete failure.')
       })
     }
   }

--- a/frontend/src/app/admin/programs/program-edit/program-edit.component.ts
+++ b/frontend/src/app/admin/programs/program-edit/program-edit.component.ts
@@ -60,23 +60,20 @@ export class ProgramEditComponent implements OnInit {
 
   handleDeleteClick() {
     const res = window.confirm("Are you sure that you would like to delete this program?")
-
+    
     if (res) {
       this.program.pipe(
         take(1),
         map(p => p.data.guid),
-        flatMap(guid => this.model.deleteProgram(guid)),
-        tap(() => {
+        flatMap(guid => this.model.deleteProgram(guid))
+      ).subscribe((deleteResponse) => {
+        if (deleteResponse) {
           this.display('delete success.')
           this.router.navigateByUrl('admin/programs/overview');
-        })
-      ).subscribe({
-        error: e => {
-          console.error(e);
-          this.display('delete failure.')
         }
+        this.display('delete failure.')
       })
-    }    
+    }
   }
 
   private _goToQueries(){

--- a/frontend/src/app/admin/programs/services/program-model.service.ts
+++ b/frontend/src/app/admin/programs/services/program-model.service.ts
@@ -136,7 +136,7 @@ export class ProgramModelService {
         return this.http.delete(`${environment.api}/protected/program/${guid}`, creds)
             .pipe(
                 map(res => res.json()),
-                map( (res: [boolean, object, Array<ApplicationFacingProgram>]) => res[0]),
+                map(res => res.deleted),
                 catchError(this.loadError)
             )
     }


### PR DESCRIPTION
Fixes #62. Fixes #63.

When a request is sent to delete a query, it always responds with
```
{
    "found": true,
    "deleted": true
}
```
Now it will respond with
```
{
    "found": null,
    "deleted": false
}
```
when the query failed to delete.


When a request is sent to delete a program, the response is always
```
[
    {
        "deleted": true
    },
    {
        "took": 6,
        "timed_out": false,
        "total": 0,
        "deleted": 0,
        "batches": 0,
        "version_conflicts": 0,
        "noops": 0,
        "retries": {
            "bulk": 0,
            "search": 0
        },
        "throttled_millis": 0,
        "requests_per_second": -1,
        "throttled_until_millis": 0,
        "failures": []
    }
]
```

Now it will respond with
```
{
    "deleted": true,
    "queries_deleted": 5
}
```
when the program successfully deleted. The 5 indicates the number of queries that were deleted that were linked to the program. It will respond with
```
{
    "deleted": false,
    "queries_deleted": 0
}
```
when the program failed to delete.

The frontend responds accordingly with success or failure messages.

I added a few unit tests on the backend for program deletion and query deletion.

