### PR TITLE
Fix circular dependencies on frontend

### DIFF
--- a/frontend/src/app/admin/programs/program-overview/helpers/index.ts
+++ b/frontend/src/app/admin/programs/program-overview/helpers/index.ts
@@ -1,3 +1,4 @@
 export * from './program-state';
 export * from './filter-message';
+export * from './update-state';
 export * from './program';

--- a/frontend/src/app/admin/programs/program-overview/helpers/program-state.ts
+++ b/frontend/src/app/admin/programs/program-overview/helpers/program-state.ts
@@ -1,7 +1,5 @@
 import { ApplicationFacingProgram } from '../../../models/program';
-import { FilterMessage } from './index';
-import { Observable } from 'rxjs';
-import { scan } from 'rxjs/operators'
+import { FilterMessage } from './filter-message';
 
 export class ProgramState {
   filter: FilterMessage;
@@ -14,44 +12,4 @@ export class ProgramState {
     this.programs = [...programs];
     this.filter = (<any>Object).assign({}, filter);
   }
-}
-
-
-export function updateState(input$: Observable<FilterMessage | ApplicationFacingProgram[] | ApplicationFacingProgram>) : Observable<ProgramState> {
-  
-  const INITIAL_STATE = new ProgramState([], new FilterMessage({ type: '', value: 'none' }));
-  
-  return input$
-    .pipe(
-      scan((state: ProgramState, update: FilterMessage | ApplicationFacingProgram[] | ApplicationFacingProgram) => {
-        if (update instanceof FilterMessage) {
-          state.filter = update;
-          return state;
-        } else if (Array.isArray(update)) {
-          state.programs = [...update].filter(program => program.guid !== undefined && program.guid !== null).sort(programComparator);
-          return state;
-        } else if (typeof update === 'object' && update.guid !== undefined) {
-          const index = state.programs.findIndex(p => p.guid === update.guid)
-    
-          if (index >= 0) {
-            state.programs[index] = update;
-          }
-          return state;
-        }
-    
-        return INITIAL_STATE;
-      }, INITIAL_STATE)
-    )
-}
-
-
-function programComparator(a: ApplicationFacingProgram, b: ApplicationFacingProgram): number {
-  const titleA = a.user.title.toUpperCase();
-  const titleB = b.user.title.toUpperCase();
-
-  if (titleA < titleB) return -1;
-
-  if (titleB < titleA) return 1;
-
-  return 0;
 }


### PR DESCRIPTION
Fixes #34.

In the src/app/admin/programs/program-overview/helpers directory, there is a circular dependency between filter-message.ts and program-state.ts. The updateState function in program-state depends on both the ProgramState class, which is in the same file (program-state), and the FilterMessage class in filter-message. The ProgramState class also depends on the FilterMessage class. I extracted the updateState function into its own file.

Now there are no circular dependency warnings when you compile the frontend.

![nocirculardependencies](https://user-images.githubusercontent.com/32050152/53762074-57bb2b00-3e84-11e9-86a8-591078bff6ad.PNG)
