### PR TITLE
Remove displayed query ID from query edit

### DIFF
--- a/frontend/src/app/admin/programs/application-edit/condition-edit-v3/condition-edit-v3.component.css
+++ b/frontend/src/app/admin/programs/application-edit/condition-edit-v3/condition-edit-v3.component.css
@@ -16,12 +16,16 @@ mat-list.ng-invalid {
   background-color: lightcoral;
 }
 
+mat-list-item {
+  white-space: nowrap;
+}
+
 .material-icons {
   cursor: pointer;
 }
 
 .question-text {
-  width: 20em;
+  width: 75%;
   margin: 0 0.5em;
 }
 

--- a/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.css
+++ b/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.css
@@ -3,30 +3,22 @@ app-condition-edit-v3 {
 }
 
 #header {
-  display: flex;
-  justify-content: space-around;
-  align-items: center;
-  width: 100%;
+  white-space: nowrap;
 }
 
-#header > button {
-  margin-left: 10px;
+#save-btn {
+  margin-left: 4vw;
 }
 
-#header > *:last-child {
-  margin-right: 10px;
-}
-
-#header > p {
-  width: 30%;
-  overflow: hidden; 
-  text-overflow: ellipsis;
+#new-condition-btn {
+  margin-left: 2vw;
 }
 
 #conditions {
   display: flex;
   flex-direction: column;
   border-top: lightgrey 1px solid;
+  margin-top: 1em;
 }
 
 main {

--- a/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.html
+++ b/frontend/src/app/admin/programs/application-edit/query-edit-v3/query-edit-v3.component.html
@@ -1,9 +1,6 @@
-
 <main>
   <section id="header">
-    <p>id: {{programQuery.data.id}}</p>
-    <div class="flex-grow"></div>
-    <button
+    <button id="save-btn"
       mat-raised-button
       color="primary"
       (click)="saveQuery()"
@@ -11,6 +8,7 @@
       save
     </button>
     <button
+      id = "new-condition-btn"
       mat-raised-button
       [style.backgroundColor]="'darkorange'"
       (click)="newCondition()"


### PR DESCRIPTION
Fixes #114.

![query-edit](https://user-images.githubusercontent.com/32050152/55028311-027ac100-4fcd-11e9-9f95-a8d036670d5b.PNG)


- Removed the displayed query ID.
- Adjusted the styling of the save button and new condition button.
- Changed the width of the conditions from a fixed width of 20em to a width of 75%.