### PR TITLE
Fix overflowing program cards

### DIFF
--- a/frontend/src/app/admin/programs/program-overview/program-detail/program-detail.component.css
+++ b/frontend/src/app/admin/programs/program-overview/program-detail/program-detail.component.css
@@ -1,6 +1,5 @@
 mat-card {
   font-family: 'Open Sans', sans-serif;
-  min-height: 15vh;
 }
 
 mat-card-title {
@@ -28,7 +27,6 @@ mat-card-actions > button[mat-button]:hover {
 
 mat-card-content {
   width: 100%;
-  min-height: 4vh;
   overflow-y: hidden;
   background-color: lightgray;
   padding: 2px 2px;

--- a/frontend/src/app/admin/programs/program-overview/program-detail/program-detail.component.css
+++ b/frontend/src/app/admin/programs/program-overview/program-detail/program-detail.component.css
@@ -1,6 +1,6 @@
 mat-card {
   font-family: 'Open Sans', sans-serif;
-  min-height: 30vh;
+  min-height: 15vh;
 }
 
 mat-card-title {

--- a/frontend/src/app/admin/programs/program-overview/program-detail/program-detail.component.css
+++ b/frontend/src/app/admin/programs/program-overview/program-detail/program-detail.component.css
@@ -1,6 +1,6 @@
 mat-card {
   font-family: 'Open Sans', sans-serif;
-  height: 35vh;
+  min-height: 30vh;
 }
 
 mat-card-title {
@@ -28,7 +28,7 @@ mat-card-actions > button[mat-button]:hover {
 
 mat-card-content {
   width: 100%;
-  height: 5vh;
+  min-height: 4vh;
   overflow-y: hidden;
   background-color: lightgray;
   padding: 2px 2px;
@@ -40,4 +40,3 @@ mat-card-content {
   position: absolute;
   right: 1em;
 }
-


### PR DESCRIPTION
Fixes #104.

![fixed-overflowing-card](https://user-images.githubusercontent.com/32050152/55030791-b3378f00-4fd2-11e9-8066-5ee8d061c3df.PNG)

- Removed program card height
- Removed program description height

So now program cards grow vertically with the amount of content they have in them. The link section on the card will be removed when PR #108 gets merged.