### PR TITLE
Fix 404 errors not being directed to frontend

### DIFF
--- a/frontend/Caddyfile
+++ b/frontend/Caddyfile
@@ -43,6 +43,6 @@
   }
 
   errors {
-    404 /index.html
+    404 index.html
   }
 }


### PR DESCRIPTION
Fixes issue #20.

Our Caddyfile is meant to direct 404 errors to the frontend app, but the syntax wasn't right. It should be index.html and not /index.html, where index.html is the file in the working directory.