### PR TITLE
Upgrade typescript on backend

### DIFF
--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -7893,9 +7893,9 @@
 			"integrity": "sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c="
 		},
 		"typescript": {
-			"version": "2.9.2",
-			"resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
-			"integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w=="
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.0.3.tgz",
+			"integrity": "sha512-kk80vLW9iGtjMnIv11qyxLqZm20UklzuR2tL0QAnDIygIUIemcZMxlMWudl9OOt76H3ntVzcTiddQ1/pAAJMYg=="
 		},
 		"uglify-js": {
 			"version": "3.5.12",

--- a/backend/package.json
+++ b/backend/package.json
@@ -33,7 +33,7 @@
     "rxjs": "^6.3.3",
     "rxjs-compat": "^6.3.3",
     "sanitize-html": "^1.20.0",
-    "typescript": "^2.9.2",
+    "typescript": "^3.0.3",
     "uuid": "^3.3.2",
     "winston": "^2.4.4"
   },


### PR DESCRIPTION
Resolves issue #127.

Upgraded typescript from 2.9.2 to 3.0.3 on the backend.

Backend unit and integration tests passed. Manual tests showed no issues. Building the backend docker image worked.