### PR TITLE
Add docker-compose for development

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,22 @@
+version: '3.2'
+services:
+
+  web:
+    build:
+      context: ./frontend
+    environment:
+      - API_SERVICE=api
+      - API_PORT=3000
+    ports:
+      - 4200:80
+
+  api:
+    build:
+      context: ./backend
+    environment:
+      - ELASTICSEARCH_URL=elasticsearch:9200
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.4.2
+    environment:
+      - discovery.type=single-node


### PR DESCRIPTION
Resolves issue #132 

Added a docker-compose.yml file for development purposes. Run `docker-compose up -d` to start up the environment. When you make changes to the frontend or backend, run `docker-compose build --no-cache web` for the frontend or `docker-compose build --no-cache api` for the backend. Then run `docker-compose up -d` to start up the environment.

The app will be served on port 4200. To log into the admin section, the username will be `user` and the password will be `password`.